### PR TITLE
Add Override Priority Events

### DIFF
--- a/express-server/jobService.js
+++ b/express-server/jobService.js
@@ -29,7 +29,7 @@ async function runJob() {
     }
 
     const currentTime = new Date();
-    const currentEvents = events
+    var currentEvents = events
         .filter((event) => event.startDate <= currentTime && currentTime <= event.endDate)
         .filter((event) => {
             // Keep all elements if ignored_events doesn't exist
@@ -48,6 +48,23 @@ async function runJob() {
 
             return !doesMatch;
         });
+
+    if (statusSettings.override_priority) {
+        const overrideEvents = [];
+        // Starting with the first override element, look for matching events
+        statusSettings.override_priority.forEach((override) => {
+            currentEvents.forEach((event) => {
+                const regex = RegExp(override,'i');
+                if (event.subject.match(regex)) {
+                    overrideEvents.push(event);
+                };
+            });
+        });
+        if (overrideEvents[0]) {
+            // Assign just the first event as our currentEvents
+            currentEvents = overrideEvents.slice(0,1);
+        }
+    }
 
     await sendReminderIfNecessary(events);
 

--- a/statusSettings.example.json
+++ b/statusSettings.example.json
@@ -10,6 +10,7 @@
             "Example placeholder text of a meeting subject that would be ignored"
         ]
     },
+    "override_priority": ["Vacation","Sick","PTO"],
     "status_events": [
         {
             "matching_words": [


### PR DESCRIPTION
Adding in a feature to allow the user to specify event subjects that override any other event. Helpful in those cases where you take a 1/2 day off/sick/whatever, but still have meetings scheduled during that timeframe.